### PR TITLE
Support for pairing with a specific Frame device

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ from frame_sdk.camera import Quality, AutofocusType
 import datetime
 
 async def main():
+    # allow the user to pair with a specific Frame device
+    pairing_code = input("Enter pairing code displayed on Frame (empty for any): ")
+    
     # the with statement handles the connection and disconnection to Frame
-    async with Frame() as f:
+    async with Frame(address=pairing_code) as f:
         # you can access the lower-level bluetooth connection via f.bluetooth, although you shouldn't need to do this often
         print(f"Connected: {f.bluetooth.is_connected()}")
 

--- a/src/frame_sdk/bluetooth.py
+++ b/src/frame_sdk/bluetooth.py
@@ -232,7 +232,10 @@ class Bluetooth:
             device: Any = filtered_list[0][0]
 
         except IndexError:
-            raise Exception("No Frame devices found")
+            if address is None:
+                raise Exception("No Frame devices found")
+            else:
+                raise Exception("No Frame devices found matching address "+address)
 
         self._btle_client = BleakClient(
             device,

--- a/src/frame_sdk/bluetooth.py
+++ b/src/frame_sdk/bluetooth.py
@@ -183,14 +183,23 @@ class Bluetooth:
 
     async def connect(
         self,
+        address: Optional[str] = None,
         print_debugging: bool = False,
         default_timeout: float = 10.0,
-    ) -> None:
+    ) -> str:
         """
         Connects to the nearest Frame device.
-        
+        `address` can optionally be provided either as the 2 digit ID shown on
+        Frame, or the device's full address (note that on MacOS, this is a
+        system generated UUID not the devices real MAC address) in order to only
+        connect to that specific device. The value should be a string, for
+        example `"4F"` or `"78D97B6B-244B-AC86-047F-BBF72ADEB1F5"`
         `print_debugging` will output the raw bytes that are sent and received from Frame if set to True.
         `default_timeout` is the default timeout for waiting for a response from Frame, in seconds.  Defaults to 10 seconds.
+        
+        returns the device address as a string. On MacOS, this is a unique UUID
+        generated for that specific device. It can be used in the `address`
+        parameter to only reconnect to that specific device.
         """
         self._print_debugging = print_debugging
         self._default_timeout = default_timeout
@@ -201,7 +210,21 @@ class Bluetooth:
         filtered_list: List[Tuple[Any, Any]] = []
         for d in devices.values():
             if self._SERVICE_UUID in d[1].service_uuids:
-                filtered_list.append(d)
+                if address is None:
+                    filtered_list.append(d)
+
+                # Filter by last two digits in the device name
+                elif len(address) == 2 and isinstance(address, str):
+                    if d[0].name.lower()[-2:] == address.lower():
+                        filtered_list.append(d)
+
+                # Filter by full device address
+                elif isinstance(address, str):
+                    if d[0].address.lower() == address.lower():
+                        filtered_list.append(d)
+
+                else:
+                    raise Exception("address should be a 2 digit hex string")
 
         # connect to closest device
         filtered_list.sort(key=lambda x: x[1].rssi, reverse=True)
@@ -233,6 +256,8 @@ class Bluetooth:
         self._tx_characteristic = service.get_characteristic(
             self._TX_CHARACTERISTIC_UUID,
         )
+        
+        return device.address
 
     async def disconnect(self) -> None:
         """

--- a/src/frame_sdk/frame.py
+++ b/src/frame_sdk/frame.py
@@ -27,9 +27,14 @@ class Frame:
         self._lua_on_wake = None
         self._callback_on_wake = None
         
-    async def __aenter__(self) -> 'Frame':
-        """Enter the asynchronous context manager."""
-        await self.ensure_connected()
+    async def __aenter__(self, address: Optional[str] = None) -> 'Frame':
+        """Enter the asynchronous context manager.
+        `address` can optionally be provided either as the 2 digit ID shown on
+        Frame, or the device's full address (note that on MacOS, this is a
+        system generated UUID not the devices real MAC address) in order to only
+        connect to that specific device. The value should be a string, for
+        example `"4F"` or `"78D97B6B-244B-AC86-047F-BBF72ADEB1F5"`"""
+        await self.ensure_connected(address)
         return self
     
     async def __aexit__(self, exc_type: Optional[type], exc_value: Optional[BaseException], traceback: Optional[object]) -> None:
@@ -37,10 +42,15 @@ class Frame:
         if self.bluetooth.is_connected():
             await self.bluetooth.disconnect()
         
-    async def ensure_connected(self) -> None:
-        """Ensure the Frame is connected, establishing a connection if not."""
+    async def ensure_connected(self, address: Optional[str] = None) -> None:
+        """Ensure the Frame is connected, establishing a connection if not.
+        `address` can optionally be provided either as the 2 digit ID shown on
+        Frame, or the device's full address (note that on MacOS, this is a
+        system generated UUID not the devices real MAC address) in order to only
+        connect to that specific device. The value should be a string, for
+        example `"4F"` or `"78D97B6B-244B-AC86-047F-BBF72ADEB1F5"`"""
         if not self.bluetooth.is_connected():
-            await self.bluetooth.connect()
+            await self.bluetooth.connect(address)
             self.bluetooth.print_debugging = Frame.debug_on_new_connection
             await self.bluetooth.send_break_signal()
             await self.inject_all_library_functions()

--- a/src/frame_sdk/frame.py
+++ b/src/frame_sdk/frame.py
@@ -16,7 +16,7 @@ class Frame:
     
     debug_on_new_connection: bool = False
 
-    def __init__(self):
+    def __init__(self, address: Optional[str] = None):
         """Initialize the Frame device and its components."""
         self.bluetooth = Bluetooth()
         self.files = Files(self)
@@ -26,15 +26,19 @@ class Frame:
         self.motion = Motion(self)
         self._lua_on_wake = None
         self._callback_on_wake = None
+        if address != "":
+            self._address = address.upper()
+        else:
+            self._address = None
         
-    async def __aenter__(self, address: Optional[str] = None) -> 'Frame':
+    async def __aenter__(self) -> 'Frame':
         """Enter the asynchronous context manager.
         `address` can optionally be provided either as the 2 digit ID shown on
         Frame, or the device's full address (note that on MacOS, this is a
         system generated UUID not the devices real MAC address) in order to only
         connect to that specific device. The value should be a string, for
         example `"4F"` or `"78D97B6B-244B-AC86-047F-BBF72ADEB1F5"`"""
-        await self.ensure_connected(address)
+        await self.ensure_connected(self._address)
         return self
     
     async def __aexit__(self, exc_type: Optional[type], exc_value: Optional[BaseException], traceback: Optional[object]) -> None:
@@ -50,7 +54,7 @@ class Frame:
         connect to that specific device. The value should be a string, for
         example `"4F"` or `"78D97B6B-244B-AC86-047F-BBF72ADEB1F5"`"""
         if not self.bluetooth.is_connected():
-            await self.bluetooth.connect(address)
+            await self.bluetooth.connect(address or self._address)
             self.bluetooth.print_debugging = Frame.debug_on_new_connection
             await self.bluetooth.send_break_signal()
             await self.inject_all_library_functions()


### PR DESCRIPTION
Optionally allow the Frame address (or pairing code) to be supplied when connecting. This matches the "ready to pair" launch screen on the Frame display. If unspecified, it retains the old behavior of connecting to any nearby Frame device. However in situations like hackathons where there are multiple Frame devices available nearby, this makes sure you connect to the correct one.